### PR TITLE
services.odysseygo.restart must be a string | Restart Policy must be in string

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   odysseygo:
     image: dionetech/odysseygo:develop
     container_name: odysseygo
-    restart: no
+    restart: "no"
     environment:
       - NETWORK=testnet
       - RPC_ACCESS=public


### PR DESCRIPTION
The `restart` policy values in Docker Compose must be provided as strings, as per the Compose file syntax
Reference: https://github.com/compose-spec/compose-spec/blob/main/spec.md#restart

**Reasons**
I'm using Linux & when run `docker-compose up` so, having this error, 
**services.odysseygo.restart must be a string**